### PR TITLE
torchaudio compatibility fixes

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -14,6 +14,7 @@ from torch_audiomentations import (
     PeakNormalization,
     Compose,
     Shift,
+    ApplyBackgroundNoise,
 )
 
 SAMPLE_RATE = 44100
@@ -84,6 +85,12 @@ if __name__ == "__main__":
     modes = ["per_batch", "per_example", "per_channel"]
     for mode in modes:
         transforms = [
+            {
+                "instance": ApplyBackgroundNoise(
+                    background_paths=TEST_FIXTURES_DIR / "bg", mode=mode, p=1.0
+                ),
+                "num_runs": 5,
+            },
             {
                 "instance": Compose(
                     transforms=[

--- a/torch_audiomentations/utils/io.py
+++ b/torch_audiomentations/utils/io.py
@@ -240,11 +240,19 @@ class Audio:
             raise ValueError()
 
         if original_samples is None:
-            original_data, _ = torchaudio.load(
-                audio_path,
-                frame_offset=original_sample_offset,
-                num_frames=original_num_samples,
-            )
+            try:
+                original_data, _ = torchaudio.load(
+                    audio_path,
+                    frame_offset=original_sample_offset,
+                    num_frames=original_num_samples,
+                )
+            except TypeError:
+                # Support legacy interface. See also https://github.com/pytorch/audio/issues/903
+                original_data, _ = torchaudio.load(
+                    audio_path,
+                    offset=original_sample_offset,
+                    num_frames=original_num_samples,
+                )
 
         else:
             original_data = original_samples[


### PR DESCRIPTION
Some torchaudio calls were giving me exceptions. I tried to upgrade from 0.6.0 to 0.7.0, but ended up spending too much time on it, and now I'm still on 0.6.0. Instead I decided to add support for their legacy interface.

See also https://github.com/pytorch/audio/issues/903